### PR TITLE
fix(yaml parser): safer multi-document yaml split

### DIFF
--- a/lib/parsed-yaml-retriever.js
+++ b/lib/parsed-yaml-retriever.js
@@ -12,7 +12,7 @@ const getParsedYaml = gh => async data => {
     const file = await promisify(gh.repos.getContent)(options)
     contents = Buffer.from(file.content, 'base64').toString()
   }
-  const docs = contents.split('---')
+  const docs = contents.split('\n---\n')
   const parsedDocs = docs.map(d => {
     return yaml.parse(d)
   })


### PR DESCRIPTION
When the document contains `---` that are not supposed to separate yaml documents (eg. in comments) then this plugin prevents it to be parsed and built. 

Splitting the string by `\n---\n` is a bit safer.