### PR TITLE
Set body parser limit size

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -19,7 +19,7 @@ const getParsedYaml = createParsedYamlRetriever(gh)
 const nullYaml = 'kind: pipeline\nname: default\ntrigger:\n  event:\n    exclude: [ "*" ]'
 
 const app = express()
-app.post('/', bodyParser.json(), async (req, res) => {
+app.post('/', bodyParser.json({limit: '50mb'}), async (req, res) => {
   console.log('Processing...')
   if (!req.headers.signature) return res.status(400).send('Missing signature')
   if (!isValidSig(req, sharedKey)) return res.status(400).send('Invalid signature')


### PR DESCRIPTION
Hello.

We've been getting an error in the plugin:
```
PayloadTooLargeError: request entity too large
   at readStream (/app/node_modules/raw-body/index.js:155:17)
   at getRawBody (/app/node_modules/raw-body/index.js:108:12)
   at read (/app/node_modules/body-parser/lib/read.js:77:3)
   at jsonParser (/app/node_modules/body-parser/lib/types/json.js:135:5)
   at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
   at next (/app/node_modules/express/lib/router/route.js:137:13)
   at Route.dispatch (/app/node_modules/express/lib/router/route.js:112:3)
   at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
   at /app/node_modules/express/lib/router/index.js:281:22
   at Function.process_params (/app/node_modules/express/lib/router/index.js:335:12)
```

This simple change fixed the issue for us. Could we merge this, please?