### PR TITLE
Include all file changes for branches/PRs

### DIFF
--- a/lib/files-changed-determiner.js
+++ b/lib/files-changed-determiner.js
@@ -11,7 +11,12 @@ const getCommit = gh => async data => {
   if (!data.build.before || data.build.before === '0000000000000000000000000000000000000000') {
     options.sha = data.build.after
     action = 'getCommit'
-  } else {
+  } else if(data.build.source !== data.repo.default_branch) {
+    // if the commit is in the non-default branch, compare against default branch
+    options.base = data.repo.default_branch
+    options.head = data.build.after
+  }
+  else {
     options.base = data.build.before
     options.head = data.build.after
   }


### PR DESCRIPTION
Hey there 👋 

Thanks for this awesome plugin! We're using it to run different pipelines depending on the files changed. So when something in a shared library changes, we would trigger all repos that use this library. 

What we noticed though, is that when working on a feature branch, it would always only include the file changes from the last commit. We kind of expected it to include all changes to the current branch or PR, ensuring that everything that depends e.g. on a shared library is always triggered.

This PR adds that. So when a commit comes from the non-default branch, it will diff the current commit against the default branch and include all file changes. 

I'm not sure this is something you want to include in this plugin or if it is feasible for you at all. Maybe it should go behind a setting? Let me know!