### PR TITLE
fix(#31): preserve skipped steps to avoid Drone DAG reference errors

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -59,7 +59,10 @@ app.post('/', bodyParser.json({limit: '50mb'}), async (req, res) => {
     }
 
     const transformedSteps = py.steps.map(s => {
-      if (!s.when || !s.when.changeset || !s.when.changeset.includes) return true
+      if (!s.when || !s.when.changeset || !s.when.changeset.includes) {
+        return s;
+      }
+      
       const requiredFiles = s.when.changeset.includes
       const matchedFiles = glob.match(requiredFiles, filesChanged, { dot: true })
       console.log('Matched files for step:', matchedFiles.length, 'Allowed matches:', requiredFiles)

--- a/plugin.js
+++ b/plugin.js
@@ -64,17 +64,15 @@ app.post('/', bodyParser.json({limit: '50mb'}), async (req, res) => {
       const matchedFiles = glob.match(requiredFiles, filesChanged, { dot: true })
       console.log('Matched files for step:', matchedFiles.length, 'Allowed matches:', requiredFiles)
 
-      if (matchedFiles.length) {
-        // Allow it through unchanged
-        return s;
-      } else {
+      if (!matchedFiles.length) {
         // Add an impossible conditional which guarantees the step gets skipped
         s.when = {
           ...s.when,
           event: { exclude: ['*']},
         }
-        return s;
       }
+
+      return s;
     })
 
     return transformedSteps.length ? yaml.stringify({ ...py, steps: transformedSteps }) : nullYaml(index)

--- a/plugin.js
+++ b/plugin.js
@@ -62,7 +62,7 @@ app.post('/', bodyParser.json({limit: '50mb'}), async (req, res) => {
       if (!s.when || !s.when.changeset || !s.when.changeset.includes) {
         return s;
       }
-      
+
       const requiredFiles = s.when.changeset.includes
       const matchedFiles = glob.match(requiredFiles, filesChanged, { dot: true })
       console.log('Matched files for step:', matchedFiles.length, 'Allowed matches:', requiredFiles)
@@ -71,7 +71,7 @@ app.post('/', bodyParser.json({limit: '50mb'}), async (req, res) => {
         // Add an impossible conditional which guarantees the step gets skipped
         s.when = {
           ...s.when,
-          event: { exclude: ['*']},
+          event: { exclude: ['*'] },
         }
       }
 


### PR DESCRIPTION
This PR preserves skipped steps and instead adds an impossible condition to them prior to output: `when: { event: { excludes: ['*'] } }`

This way, Drone will know about all steps and can construct the complete DAG when using `depends_on` without throwing reference errors.